### PR TITLE
link travis badge to dbpedia repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DBpedia Ontology Issue tracker
 
-[![Build Status](https://travis-ci.org/gcpdev/ontology-tracker.svg?branch=master)](https://travis-ci.org/gcpdev/ontology-tracker)
+[![Build Status](https://travis-ci.org/dbpedia/ontology-tracker.svg?branch=master)](https://travis-ci.org/dbpedia/ontology-tracker)
 
  This repository is only used as an issue tracker for modification requests in the DBpedia Ontology.
 


### PR DESCRIPTION
badge still links to previous repo i think...