### PR TITLE
Fix incorrect type inference for country entities due to restrictive property domain and broken ontology paths

### DIFF
--- a/ontology/ontology.ttl
+++ b/ontology/ontology.ttl
@@ -17395,7 +17395,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 
 :leadership
     a rdf:Property, owl:DatatypeProperty ;
-    rdfs:domain :Person ;
+    rdfs:domain :PopulatedPlace ;
     rdfs:label "Führung"@de, "leadership"@en ;
     rdfs:range xsd:string ;
     prov:wasDerivedFrom <http://mappings.dbpedia.org/index.php/OntologyProperty:leadership> .

--- a/src/main/java/org/dbpedia/ontologytracker/RDFUnitValidate.java
+++ b/src/main/java/org/dbpedia/ontologytracker/RDFUnitValidate.java
@@ -20,7 +20,7 @@ import org.apache.log4j.Logger;
 public class RDFUnitValidate {
 
     TestSuite ts = null;
-    static String defaultSchema = "ontology/dbo.tests.shapes.ttl";
+    static String defaultSchema = "guidelines/dbo.tests.shapes.ttl";
     private static Logger L = Logger.getLogger(RDFUnitValidate.class);
 
     public RDFUnitValidate() {

--- a/src/main/java/org/dbpedia/ontologytracker/ValidateOntology.java
+++ b/src/main/java/org/dbpedia/ontologytracker/ValidateOntology.java
@@ -20,7 +20,7 @@ public class ValidateOntology {
 
     private static Logger L = Logger.getLogger(ValidateOntology.class);
 
-    private static final File DBPEDIA_ONTOLOGY = new File("ontology/dbpedia_ontology.ttl");
+    private static final File DBPEDIA_ONTOLOGY = new File("ontology/ontology.ttl");
     private static final String baseUri = "http://dbpedia.org/ontology/";
     private static String outdir = "result";
 

--- a/src/test/java/org/dbpedia/ontologytracker/TestRunner.java
+++ b/src/test/java/org/dbpedia/ontologytracker/TestRunner.java
@@ -18,7 +18,7 @@ public class TestRunner {
     public RdfReader getInputData() throws RdfReaderException {
         return new RdfModelReader(
                 RdfReaderFactory.createFileOrResourceReader(
-                        "ontology/dbpedia_ontology.ttl", "").read());
+                        "ontology/ontology.ttl", "").read());
     }
     ;
 


### PR DESCRIPTION
## Description

This PR fixes an issue where country entities (e.g., Italy) were incorrectly inferred as `dbo:Person`.

### What was done
- Identified that the `:leadership` property had an incorrect domain of `:Person`, which caused wrong type inference when used in country infobox mappings.
- Updated the domain of `:leadership` to `:PopulatedPlace` in `ontology/ontology.ttl` to ensure correct classification.

### Issue in Ontology Tracker
- Discovered that the ontology-tracker had hardcoded file paths pointing to non-existent directories.
- Because of this, the tool failed to load ontology and SHACL files, preventing proper validation and making it harder to detect such issues.

### Fix
- Corrected the file paths in the ontology-tracker to properly load ontology and SHACL files.
- Restored validation functionality to ensure such inconsistencies can be detected in the future.

These changes prevent incorrect type propagation and improve overall ontology consistency and validation reliability.

Issue link-: https://github.com/dbpedia/ontology-tracker/issues/40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the domain classification of the leadership property to apply to populated places instead of persons. This ensures the ontology schema accurately reflects the appropriate entity types for this property.

* **Chores**
  * Updated validation and test suite configurations to reference the latest ontology schema definitions and test resources, ensuring consistent usage across the ontology tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->